### PR TITLE
Add a method for changing the logged field name for the base message

### DIFF
--- a/structlog4j-json/src/main/java/com/github/structlog4j/json/JsonFormatter.java
+++ b/structlog4j-json/src/main/java/com/github/structlog4j/json/JsonFormatter.java
@@ -16,11 +16,16 @@ import java.io.StringWriter;
  */
 public class JsonFormatter implements IFormatter<JsonObjectBuilder> {
 
-    private static final String FIELD_MESSAGE = "message";
+    private String fieldMessage = "message";
     private static final String FIELD_MESSAGE_2 = "message2";
 
     private static final JsonFormatter INSTANCE = new JsonFormatter();
     public static JsonFormatter getInstance() {return INSTANCE;}
+
+    public IFormatter<JsonObjectBuilder> setMessageName(String field) {
+        fieldMessage = field;
+        return this;
+    }
 
     @Override
     public final JsonObjectBuilder start(Logger log) {
@@ -29,16 +34,16 @@ public class JsonFormatter implements IFormatter<JsonObjectBuilder> {
 
     @Override
     public final IFormatter<JsonObjectBuilder> addMessage(Logger log, JsonObjectBuilder bld, String message) {
-        bld.add(FIELD_MESSAGE,message);
+        bld.add(fieldMessage,message);
         return this;
     }
 
     @Override
     public final IFormatter<JsonObjectBuilder> addKeyValue(Logger log, JsonObjectBuilder bld, String key, Object value) {
-        // avoid overriding the "message" field
-        if (key.equals(FIELD_MESSAGE)) {
+        // avoid overriding the "fieldMessage" field
+        if (key.equals(fieldMessage)) {
             key = FIELD_MESSAGE_2;
-            log.warn("Key 'message' renamed to 'message2' in order to avoid overriding default JSON message field. Please correct in your code.");
+            log.warn("Key '{}' renamed to '{}' in order to avoid overriding default JSON message field. Please correct in your code.",fieldMessage,FIELD_MESSAGE_2);
         }
 
         // different methods per type

--- a/structlog4j-json/src/test/java/com/github/structlog4j/json/test/BasicJsonTests.java
+++ b/structlog4j-json/src/test/java/com/github/structlog4j/json/test/BasicJsonTests.java
@@ -48,6 +48,17 @@ public class BasicJsonTests {
     }
 
     @Test
+    public void changeMessageStringTest() {
+        // create a separate formatter since we're changing the internals
+        StructLog4J.setFormatter((new JsonFormatter()).setMessageName("foo"));
+        log.error("This is an error");
+
+        assertEquals(entries.toString(),1,entries.size());
+        assertJsonMessage(entries,0);
+        assertMessage(entries,0, Level.ERROR,"{\"foo\":\"This is an error\"}",false);
+    }
+
+    @Test
     public void singleKeyValueTest() {
         log.error("This is an error","user","Jacek");
 

--- a/structlog4j-test/src/main/java/org/slf4j/impl/TestLogger.java
+++ b/structlog4j-test/src/main/java/org/slf4j/impl/TestLogger.java
@@ -225,7 +225,9 @@ public class TestLogger implements Logger {
 
     @Override
     public void warn(String format, Object arg1, Object arg2) {
-        throw new RuntimeException("Not used");
+        // used in internal warnings
+        format = format.replace("{}","%s");
+        entries.add(new LogEntry(Level.WARN,String.format(format,arg1,arg2), Optional.empty()));
     }
 
     @Override

--- a/structlog4j-yaml/src/main/java/com/github/structlog4j/yaml/YamlFormatter.java
+++ b/structlog4j-yaml/src/main/java/com/github/structlog4j/yaml/YamlFormatter.java
@@ -6,7 +6,6 @@ import java.util.Map;
 import org.slf4j.Logger;
 import org.yaml.snakeyaml.DumperOptions;
 import org.yaml.snakeyaml.Yaml;
-import org.yaml.snakeyaml.nodes.Tag;
 
 /**
  * Basic YAML formatter using the standard SnakeYaml library
@@ -27,11 +26,16 @@ public class YamlFormatter implements IFormatter<Map<String,String>> {
         }
     };
 
-    private static final String FIELD_MESSAGE = "message";
+    private String fieldMessage = "message";
     private static final String FIELD_MESSAGE_2 = "message2";
 
     private static final YamlFormatter INSTANCE = new YamlFormatter();
     public static YamlFormatter getInstance() {return INSTANCE;}
+
+    public IFormatter<Map<String,String>> setMessageName(String field) {
+        fieldMessage = field;
+        return this;
+    }
 
     @Override
     public final Map<String,String> start(Logger log) {
@@ -40,16 +44,16 @@ public class YamlFormatter implements IFormatter<Map<String,String>> {
 
     @Override
     public final IFormatter<Map<String,String>> addMessage(Logger log, Map<String,String> bld, String message) {
-        bld.put(FIELD_MESSAGE,message);
+        bld.put(fieldMessage,message);
         return this;
     }
 
     @Override
     public final IFormatter<Map<String,String>> addKeyValue(Logger log, Map<String,String> bld, String key, Object value) {
         // avoid overriding the "message" field
-        if (key.equals(FIELD_MESSAGE)) {
+        if (key.equals(fieldMessage)) {
             key = FIELD_MESSAGE_2;
-            log.warn("Key 'message' renamed to 'message2' in order to avoid overriding default YAML message field. Please correct in your code.");
+            log.warn("Key '{}' renamed to '{}' in order to avoid overriding default YAML message field. Please correct in your code.",fieldMessage,FIELD_MESSAGE_2);
         }
 
         bld.put(key, String.valueOf(value));

--- a/structlog4j-yaml/src/test/java/com/github/structlog4j/yaml/test/BasicYamlTests.java
+++ b/structlog4j-yaml/src/test/java/com/github/structlog4j/yaml/test/BasicYamlTests.java
@@ -48,6 +48,17 @@ public class BasicYamlTests {
     }
 
     @Test
+    public void changeMessageStringTest() {
+        // create a separate formatter since we're changing the internals
+        StructLog4J.setFormatter((new YamlFormatter()).setMessageName("foo"));
+        log.error("This is an error");
+
+        assertEquals(entries.toString(),1,entries.size());
+        assertYamlMessage(entries,0);
+        assertMessage(entries,0, Level.ERROR,"foo: This is an error",false);
+    }
+
+    @Test
     public void singleKeyValueTest() {
         log.error("This is an error","user","Jacek");
 


### PR DESCRIPTION
This allows for alternative structures for the JSON output that fit in better with other logging frameworks/parsing backends for the structured output.